### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/skills.yml
+++ b/.github/workflows/skills.yml
@@ -1,5 +1,8 @@
 name: Skills
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/tartinerlabs/skills/security/code-scanning/2](https://github.com/tartinerlabs/skills/security/code-scanning/2)

In general, this issue is fixed by explicitly defining a `permissions` block for the workflow (or for each job) that grants only the scopes required. For a workflow that just checks out code and runs local commands, `contents: read` is typically sufficient. Additional scopes (like `pull-requests: write`) should only be added if the workflow actually needs them.

For this specific workflow, the simplest, least invasive fix is to add a top-level `permissions` block right after the `name:` (or before `jobs:`) so it applies to all jobs. Based on the visible steps—`actions/checkout`, `setup-node`, `pnpm dlx` installs, and running tools—there is no clear need to write to the repository via `GITHUB_TOKEN`, so we can restrict to `contents: read`. No imports or other code changes are necessary; we only modify `.github/workflows/skills.yml` to insert the `permissions` section.

Concretely:
- Edit `.github/workflows/skills.yml`.
- Insert:
  ```yaml
  permissions:
    contents: read
  ```
  after the `name: Skills` line (line 1) and before the `on:` block (line 3).  
This will satisfy CodeQL’s requirement and keep `GITHUB_TOKEN` limited to read-only repository contents for this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
