### PR TITLE
Make commit and GitLeaks workflows safe and current

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -2,5 +2,6 @@ export default {
   extends: ["@commitlint/config-conventional"],
   rules: {
     "scope-empty": [2, "always"],
+    "header-max-length": [2, "always", 50],
   },
 };

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: commit
 description: Use when committing changes, staging files, saving work, or making a git commit. Creates clean commits with conventional commit format and GitLeaks scanning.
-allowed-tools: Read Bash(git:*)
+allowed-tools: Read Bash(git:*) Bash(gitleaks:*)
 model: haiku
 effort: low
 ---
@@ -24,21 +24,22 @@ Read ALL rule files before proceeding — do not skip or ask:
 
 ## Pre-Commit Security Check
 
-Before committing, ensure GitLeaks is configured:
+Scan staged changes for secrets before every commit:
 
-1. Check for `.husky/pre-commit` containing `gitleaks protect`
-2. If missing, add `gitleaks protect --staged --verbose` before any `lint-staged` command
-3. If `.husky/` doesn't exist, run `pnx husky init` first
+1. Run `gitleaks git --staged --redact --verbose` after staging.
+2. If GitLeaks reports a leak, **STOP** — do not commit. Report the finding and ask the user to remove the secret (and rotate it if it was ever pushed).
+3. If GitLeaks is not installed (command not found), **STOP** — do not commit and do not install it implicitly. Tell the user to install it (`brew install gitleaks` or equivalent) and re-run.
+
+Never edit `.husky/`, `commitlint`, or other project tooling as part of a commit. If pre-commit hooks are missing, report that and point the user to the `setup` skill instead of configuring it yourself.
 
 ## Workflow
 
-1. **Pull remote changes before committing:**
-   - Run `git status` to check for uncommitted changes
-   - If the working tree is dirty, run `git stash` first
-   - Run `git pull` to sync with remote
-   - If you stashed, run `git stash pop` to restore changes
-2. Show current `git status` and analyse all changes
-3. Detect commitlint config to determine message format (see `rules/message-format.md`)
-4. Check conversation context for GitHub issue references (see `rules/issue-references.md`)
-5. Assess scope of changes (see `rules/change-scope.md`)
-6. Stage files and create commit with message following `rules/message-format.md`
+A commit request stages and commits only — it must never pull, stash, restore stashes, or rewrite project tooling.
+
+1. Show current `git status` and analyse all changes
+2. Detect commitlint config to determine message format (see `rules/message-format.md`)
+3. Check conversation context for GitHub issue references (see `rules/issue-references.md`)
+4. Assess scope of changes (see `rules/change-scope.md`)
+5. Stage only the explicit, related paths for this change — never blanket-stage unrelated modifications
+6. Run the Pre-Commit Security Check above
+7. Create the commit with a message following `rules/message-format.md`

--- a/skills/commit/rules/message-format.md
+++ b/skills/commit/rules/message-format.md
@@ -4,7 +4,7 @@ impact: HIGH
 tags: commit, message, format, 50-char
 ---
 
-**Rule**: Subject line maximum 72 characters. Use present tense verbs. Be specific but concise.
+**Rule**: Subject line maximum 50 characters. Use present tense verbs. Be specific but concise.
 
 ### Detect commitlint
 
@@ -33,7 +33,7 @@ docs: update API usage examples
 
 **Types**: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
 
-- The 72-character limit includes the `type: ` prefix
+- The 50-character limit includes the `type: ` prefix
 - Use scope only when it adds clarity: `fix(auth): handle expired token redirect`
 - Description starts with lowercase verb
 

--- a/skills/security/SKILL.md
+++ b/skills/security/SKILL.md
@@ -26,7 +26,7 @@ Read individual rule files in `rules/` for detailed explanations and examples.
 
 Classify the request before acting, and default to read-only when intent is ambiguous or diagnostic:
 
-- **Audit (read-only, default)** — "audit", "review", "check", "scan", "diagnose", or any unclear request. Produce an evidence-backed report and make NO file edits. Read-only scans (including `gitleaks detect`) are allowed; setting up hooks or editing code is not.
+- **Audit (read-only, default)** — "audit", "review", "check", "scan", "diagnose", or any unclear request. Produce an evidence-backed report and make NO file edits. Read-only scans (including `gitleaks git --redact`) are allowed; setting up hooks or editing code is not.
 - **Fix** — the user explicitly asks to fix, set up, harden, apply, or says "audit and fix". Only then run the GitLeaks Setup and any remediation steps.
 
 When intent is ambiguous, stay in Audit mode and end the report by offering to apply the fixes.
@@ -61,7 +61,7 @@ Scan the codebase against every rule in `rules/`. Search for vulnerability patte
 Only when user passes `--scan-history`. This is a read-only scan, allowed in either mode:
 
 ```bash
-gitleaks detect --source . --verbose
+gitleaks git --redact --verbose
 ```
 
 ### Step 4: GitLeaks Setup (fix mode only)
@@ -71,7 +71,8 @@ Skip this step entirely in Audit mode. Only run it when the request is in Fix mo
 Ensure GitLeaks is configured in the project's pre-commit hook:
 
 1. Check if `.husky/pre-commit` exists and contains `gitleaks`
-2. If missing, set up Husky and add `gitleaks protect --staged --verbose` before any `lint-staged` command
+2. If missing, set up Husky and add `gitleaks git --staged --redact --verbose` before any `lint-staged` command
+3. If the hook uses the legacy `gitleaks protect` command (deprecated and non-redacting), rewrite it to `gitleaks git --staged --redact --verbose`
 
 ## Assumptions
 

--- a/skills/setup/rules/gitleaks.md
+++ b/skills/setup/rules/gitleaks.md
@@ -15,7 +15,7 @@ brew install gitleaks
 Add to `.husky/pre-commit` as the **first command** (before lint-staged):
 
 ```bash
-gitleaks protect --staged --verbose
+gitleaks git --staged --redact --verbose
 ```
 
 This runs before lint-staged so secrets are caught before any other processing.

--- a/skills/setup/rules/husky.md
+++ b/skills/setup/rules/husky.md
@@ -15,7 +15,7 @@ This creates a `.husky/` directory and a default `pre-commit` hook.
 The final `.husky/pre-commit` is assembled by other rules (GitLeaks, lint-staged). The expected order is:
 
 ```bash
-gitleaks protect --staged --verbose
+gitleaks git --staged --redact --verbose
 pnx lint-staged
 ```
 


### PR DESCRIPTION
Reworks the `commit` skill so a commit request only inspects the repo and stages explicit, related paths — it no longer pulls, stashes, or rewrites `.husky`/commitlint tooling. It now runs `gitleaks git --staged --redact` before every commit and stops with a remediation message (never an implicit install) if GitLeaks is missing or a leak is found.

## Changes
- **`skills/commit/SKILL.md`** — removed the stash/pull/stash-pop workflow and `.husky/` editing; added `Bash(gitleaks:*)` to `allowed-tools`; rewrote the pre-commit security check to `gitleaks git --staged --redact` with fail-closed behaviour; stages only explicit related paths.
- **`skills/commit/rules/message-format.md`** — subject-line limit corrected 72 → 50 to match the documented limit.
- **`commitlint.config.ts`** — added `header-max-length: [2, "always", 50]` alongside the existing `scope-empty` rule.
- **`skills/setup/rules/gitleaks.md`, `skills/setup/rules/husky.md`, `skills/security/SKILL.md`** — replaced legacy `gitleaks protect` / `gitleaks detect` with current `gitleaks git` syntax.

Verified with gitleaks 8.30.1 and by loading the config via commitlint: a valid short subject passes, an 80-char subject fails on `header-max-length`, and `scope-empty` still fires.

Closes #42.

https://claude.ai/code/session_0183ouvicBQZssp5Ze7DSo2Y