### PR TITLE
Normalize skill content consistency

### DIFF
--- a/skills/github-actions/SKILL.md
+++ b/skills/github-actions/SKILL.md
@@ -115,8 +115,8 @@ Skip this step entirely in Audit mode — report **all** rule violations found i
 
 Read individual rule files for detailed checks and examples:
 
-| Rule | Severity | File |
-|------|----------|------|
+| Rule | Impact | File |
+|------|--------|------|
 | Action pinning | HIGH | `rules/action-pinning.md` |
 | Permissions | HIGH | `rules/permissions.md` |
 | Concurrency | MEDIUM | `rules/concurrency.md` |

--- a/skills/github-actions/rules/action-pinning.md
+++ b/skills/github-actions/rules/action-pinning.md
@@ -1,15 +1,15 @@
-# Action Pinning
+---
+title: Action Pinning
+impact: HIGH
+tags: actions, pinning, sha, supply-chain
+---
 
-**Severity: HIGH**
-
-Pin all actions to prevent supply-chain attacks and ensure reproducible builds.
-
-## Rule
+**Rule**: Pin all actions to prevent supply-chain attacks and ensure reproducible builds.
 
 - **GitHub-owned actions** (`actions/*`): use version tags (e.g., `@v4`)
 - **Third-party actions** (everything else): pin to full commit SHA with version comment
 
-## Incorrect
+### Incorrect
 
 ```yaml
 # Third-party action using version tag — vulnerable to tag mutation
@@ -17,7 +17,7 @@ Pin all actions to prevent supply-chain attacks and ensure reproducible builds.
 - uses: JamesIves/github-pages-deploy-action@v4
 ```
 
-## Correct
+### Correct
 
 ```yaml
 # GitHub-owned — version tags are fine
@@ -29,13 +29,13 @@ Pin all actions to prevent supply-chain attacks and ensure reproducible builds.
 - uses: JamesIves/github-pages-deploy-action@6c2391ed697a5e80688e3b2d0e42e74bac79deed  # v4.7.3
 ```
 
-## How to Find the SHA
+### How to Find the SHA
 
 ```bash
 # Look up the commit SHA for a specific version tag
 gh api repos/{owner}/{repo}/git/ref/tags/{tag} --jq '.object.sha'
 ```
 
-## Why This Matters
+### Why This Matters
 
 Version tags are mutable — a malicious actor who gains access to a repository can point an existing tag to a different commit containing malicious code. Commit SHAs are immutable and cryptographically verified.

--- a/skills/github-actions/rules/caching.md
+++ b/skills/github-actions/rules/caching.md
@@ -1,14 +1,12 @@
-# Caching
+---
+title: Caching
+impact: MEDIUM
+tags: caching, dependencies, setup-actions, performance
+---
 
-**Severity: MEDIUM**
+**Rule**: Cache package manager dependencies to speed up workflow runs. Always enable caching when using setup actions for Node.js, Python, Go, or other ecosystems.
 
-Cache package manager dependencies to speed up workflow runs.
-
-## Rule
-
-Always enable caching when using setup actions for Node.js, Python, Go, or other ecosystems.
-
-## Incorrect
+### Incorrect
 
 ```yaml
 # No caching — downloads all dependencies every run
@@ -18,7 +16,7 @@ Always enable caching when using setup actions for Node.js, Python, Go, or other
 - run: pnpm install --frozen-lockfile
 ```
 
-## Correct
+### Correct
 
 ```yaml
 # Caching enabled — reuses dependencies across runs
@@ -29,7 +27,7 @@ Always enable caching when using setup actions for Node.js, Python, Go, or other
 - run: pnpm install --frozen-lockfile
 ```
 
-## Cache Parameters by Ecosystem
+### Cache Parameters by Ecosystem
 
 | Setup Action | Cache Parameter |
 |-------------|----------------|
@@ -38,6 +36,6 @@ Always enable caching when using setup actions for Node.js, Python, Go, or other
 | `actions/setup-go@v5` | `cache: true` |
 | `actions/setup-java@v4` | `cache: 'maven'` / `'gradle'` |
 
-## Why This Matters
+### Why This Matters
 
 Without caching, every workflow run downloads and installs all dependencies from scratch. Caching can reduce install times from minutes to seconds, saving compute minutes and providing faster feedback.

--- a/skills/github-actions/rules/concurrency.md
+++ b/skills/github-actions/rules/concurrency.md
@@ -1,14 +1,12 @@
-# Concurrency
+---
+title: Concurrency
+impact: MEDIUM
+tags: concurrency, cancel-in-progress, workflow
+---
 
-**Severity: MEDIUM**
+**Rule**: Use concurrency groups to cancel redundant in-progress runs. Add a `concurrency` block to every workflow that cancels in-progress runs when a new commit is pushed to the same branch.
 
-Use concurrency groups to cancel redundant in-progress runs.
-
-## Rule
-
-Add a `concurrency` block to every workflow that cancels in-progress runs when a new commit is pushed to the same branch.
-
-## Incorrect
+### Incorrect
 
 ```yaml
 # No concurrency — multiple runs stack up on rapid pushes
@@ -24,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 ```
 
-## Correct
+### Correct
 
 ```yaml
 name: CI
@@ -43,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
 ```
 
-## When NOT to Cancel
+### When NOT to Cancel
 
 For deployment workflows to production, you may want to queue instead of cancel:
 
@@ -53,6 +51,6 @@ concurrency:
   cancel-in-progress: false  # queue instead of cancel
 ```
 
-## Why This Matters
+### Why This Matters
 
 Without concurrency groups, pushing multiple commits in quick succession creates parallel workflow runs that waste compute minutes and may cause race conditions in deployments.

--- a/skills/github-actions/rules/matrix.md
+++ b/skills/github-actions/rules/matrix.md
@@ -1,14 +1,12 @@
-# Matrix Strategy
+---
+title: Matrix Strategy
+impact: LOW
+tags: matrix, parallel, fail-fast, ci
+---
 
-**Severity: LOW**
+**Rule**: Use matrix strategies to run parallel tasks like lint, test, and build with fast failure. When a CI workflow has multiple independent commands (lint, test, build), use a matrix strategy to run them in parallel instead of sequentially in a single job.
 
-Use matrix strategies to run parallel tasks like lint, test, and build with fast failure.
-
-## Rule
-
-When a CI workflow has multiple independent commands (lint, test, build), use a matrix strategy to run them in parallel instead of sequentially in a single job.
-
-## Incorrect
+### Incorrect
 
 ```yaml
 # Sequential — slow, waits for each step to finish before starting the next
@@ -27,7 +25,7 @@ jobs:
       - run: pnpm build
 ```
 
-## Correct
+### Correct
 
 ```yaml
 # Parallel — all tasks run simultaneously, fails fast on first failure
@@ -48,20 +46,20 @@ jobs:
       - run: pnpm ${{ matrix.command }}
 ```
 
-## Fail Fast
+### Fail Fast
 
 `fail-fast: true` cancels all remaining matrix jobs as soon as one fails. This saves compute minutes and gives faster feedback — if lint fails, there's no point waiting for build to finish.
 
-## When to Use
+### When to Use
 
 - CI pipelines with multiple independent commands (lint, test, build, typecheck)
 - Tasks that don't depend on each other's output
 
-## When NOT to Use
+### When NOT to Use
 
 - Commands that must run in order (e.g., build before deploy)
 - Single-command workflows where a matrix adds unnecessary complexity
 
-## Why This Matters
+### Why This Matters
 
 Running tasks in parallel reduces total CI time from the sum of all tasks to the duration of the slowest task. Combined with `fail-fast`, broken builds surface faster.

--- a/skills/github-actions/rules/node-version.md
+++ b/skills/github-actions/rules/node-version.md
@@ -1,14 +1,12 @@
-# Node Version
+---
+title: Node Version
+impact: MEDIUM
+tags: node, lts, setup-node, versioning
+---
 
-**Severity: MEDIUM**
+**Rule**: Always use LTS aliases instead of hardcoded version numbers. Use `lts/*` for the current LTS release. This stays current automatically without manual updates.
 
-Always use LTS aliases instead of hardcoded version numbers.
-
-## Rule
-
-Use `lts/*` for the current LTS release. This stays current automatically without manual updates.
-
-## Incorrect
+### Incorrect
 
 ```yaml
 # Hardcoded version — goes stale, requires manual bumps
@@ -22,7 +20,7 @@ Use `lts/*` for the current LTS release. This stays current automatically withou
     node-version-file: '.node-version'
 ```
 
-## Correct
+### Correct
 
 ```yaml
 # LTS alias — always resolves to the latest LTS
@@ -31,7 +29,7 @@ Use `lts/*` for the current LTS release. This stays current automatically withou
     node-version: 'lts/*'
 ```
 
-## Available Aliases
+### Available Aliases
 
 | Alias | Resolves to |
 |-------|-------------|
@@ -39,6 +37,6 @@ Use `lts/*` for the current LTS release. This stays current automatically withou
 | `lts/-1` | Previous LTS (for compatibility testing) |
 | `latest` | Latest release including non-LTS (avoid in CI) |
 
-## Why This Matters
+### Why This Matters
 
 Hardcoded versions go stale and require manual updates when new LTS releases come out. LTS aliases ensure workflows always use a supported, stable version without maintenance overhead.

--- a/skills/github-actions/rules/permissions.md
+++ b/skills/github-actions/rules/permissions.md
@@ -1,14 +1,12 @@
-# Permissions
+---
+title: Permissions
+impact: HIGH
+tags: permissions, least-privilege, security
+---
 
-**Severity: HIGH**
+**Rule**: Every workflow must declare explicit permissions using the principle of least privilege. Add a top-level `permissions` block to every workflow. Only grant the minimum permissions required.
 
-Every workflow must declare explicit permissions using the principle of least privilege.
-
-## Rule
-
-Add a top-level `permissions` block to every workflow. Only grant the minimum permissions required.
-
-## Incorrect
+### Incorrect
 
 ```yaml
 # No permissions block — defaults to broad read/write access
@@ -21,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
 ```
 
-## Correct
+### Correct
 
 ```yaml
 name: CI
@@ -38,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
 ```
 
-## Common Permission Scopes
+### Common Permission Scopes
 
 | Scope | When to use |
 |-------|-------------|
@@ -49,7 +47,7 @@ jobs:
 | `packages: write` | Publishing to GitHub Packages |
 | `id-token: write` | OIDC token for cloud deployments |
 
-## Per-Job Permissions
+### Per-Job Permissions
 
 For workflows with multiple jobs needing different access, use job-level permissions:
 
@@ -71,6 +69,6 @@ jobs:
       - uses: actions/checkout@v4
 ```
 
-## Why This Matters
+### Why This Matters
 
 Without explicit permissions, workflows default to broad read/write access to the repository. A compromised action or workflow could modify code, create releases, or access secrets.

--- a/skills/github-actions/rules/triggers.md
+++ b/skills/github-actions/rules/triggers.md
@@ -1,14 +1,12 @@
-# Triggers
+---
+title: Triggers
+impact: LOW
+tags: triggers, push, pull-request, paths
+---
 
-**Severity: LOW**
+**Rule**: Use sensible, scoped triggers to avoid unnecessary workflow runs. Always scope `push` and `pull_request` triggers to specific branches. Avoid triggering on every branch.
 
-Use sensible, scoped triggers to avoid unnecessary workflow runs.
-
-## Rule
-
-Always scope `push` and `pull_request` triggers to specific branches. Avoid triggering on every branch.
-
-## Incorrect
+### Incorrect
 
 ```yaml
 # Triggers on every branch push — wasteful
@@ -20,7 +18,7 @@ on:
   pull_request:
 ```
 
-## Correct
+### Correct
 
 ```yaml
 # Scoped to main branch
@@ -31,7 +29,7 @@ on:
     branches: [main]
 ```
 
-## Path Filtering
+### Path Filtering
 
 For monorepos or projects with distinct areas, use path filters to only run relevant workflows:
 
@@ -51,7 +49,7 @@ on:
       - 'pnpm-lock.yaml'
 ```
 
-## Common Trigger Patterns
+### Common Trigger Patterns
 
 | Pattern | Use case |
 |---------|----------|
@@ -60,6 +58,6 @@ on:
 | `workflow_dispatch` | Manual trigger |
 | `schedule: cron` | Periodic jobs (e.g., dependency updates) |
 
-## Why This Matters
+### Why This Matters
 
 Overly broad triggers waste compute minutes and create noise in the Actions tab. Scoping triggers ensures workflows only run when relevant code changes.

--- a/skills/project-structure/SKILL.md
+++ b/skills/project-structure/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: project-structure
 description: Use when deciding where code should live, organising files, or auditing project structure. Checks colocation, grouping, and directory anti-patterns.
-allowed-tools: Read Glob Grep Edit Bash(git:*)
+allowed-tools: Read Glob Grep Edit Bash(git:*) Bash(mkdir:*)
 model: haiku
 effort: medium
 ---
@@ -60,6 +60,7 @@ Based on project type and existing patterns, recommend where new code should liv
 ### Step 4: Fix
 
 Apply fixes for each violation:
-1. Move files to their correct location using `git mv` to preserve git history
-2. Update all import paths in dependent files
-3. Verify no broken imports remain after moves
+1. Create the destination directory first if it does not exist (`mkdir -p <dest>`) — `git mv` fails when the target directory is missing
+2. Move files to their correct location using `git mv` to preserve git history
+3. Update all import paths in dependent files
+4. Verify no broken imports remain after moves

--- a/skills/project-structure/SKILL.md
+++ b/skills/project-structure/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: project-structure
 description: Use when deciding where code should live, organising files, or auditing project structure. Checks colocation, grouping, and directory anti-patterns.
-allowed-tools: Read Glob Grep
+allowed-tools: Read Glob Grep Edit Bash(git:*)
 model: haiku
 effort: medium
 ---
@@ -33,8 +33,33 @@ Scan for project indicators to determine the appropriate organisation approach:
 
 ### Step 2: Audit
 
-Check the existing structure against all rules. Report violations grouped by severity with directory paths.
+Check the existing structure against all rules. Report violations grouped by rule with directory paths:
+
+```
+## Project Structure Audit Results
+
+### HIGH Severity
+- `src/helpers/formatDate.ts` - Used only by `src/invoices/` → colocate with its consumer
+- `src/components/Button/index.tsx` - Barrel-only directory → import the component directly
+
+### MEDIUM Severity
+- `src/` - Flat file dump with no feature or layer grouping → group by feature
+
+### Summary
+| Rule | Violations | Directories |
+|------|-----------|-------------|
+| Colocation | X | N |
+| Anti-patterns | Y | N |
+| **Total** | **X+Y** | **N** |
+```
 
 ### Step 3: Recommend
 
 Based on project type and existing patterns, recommend where new code should live. Always prioritise colocation.
+
+### Step 4: Fix
+
+Apply fixes for each violation:
+1. Move files to their correct location using `git mv` to preserve git history
+2. Update all import paths in dependent files
+3. Verify no broken imports remain after moves

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -37,6 +37,8 @@ Before installing anything, scan for existing configurations:
 
 Read each rule file for detailed setup instructions and config files.
 
+> These tables use a `Purpose` column rather than the `Impact` column found in audit skills — setup rules are install guides for tools to add, not severity-ranked findings, so there is no impact level to report.
+
 ### Auto-install (always set up when missing)
 
 | Tool | Purpose | Rule |

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -14,7 +14,7 @@ Read individual rule files in `rules/` for detailed explanations and code exampl
 
 Determine the test type from the user's request:
 
-- **E2E / browser testing** (keywords: "e2e", "end-to-end", "browser", "playwright", "page interaction", "screenshot") → Tell the user to use a browser/E2E testing skill instead and stop.
+- **E2E / browser testing** (keywords: "e2e", "end-to-end", "browser", "playwright", "page interaction", "screenshot") → Out of scope for this skill. Point the user to their agent's own browser/E2E automation tooling (e.g. Playwright, or a dedicated browser-automation capability) and stop.
 - **Unit / component testing** → Proceed with the workflow below.
 
 ## Mode Detection


### PR DESCRIPTION
Normalizes cross-skill consistency per issue #46. No rule guidance or examples were dropped; content-only.

## Changes
- **Rule-file format (C1)** — converts the 7 `skills/github-actions/rules/*.md` files from prose `# Heading` + `**Severity**` style to the YAML-frontmatter (`title` / `impact` / `tags`) format used by the other 62 rule files, so they can be filtered by impact and tag. Severity values carry over (action-pinning/permissions HIGH; caching/concurrency/node-version MEDIUM; matrix/triggers LOW).
- **Severity vocabulary (C2)** — standardizes the rule-overview column on `Impact`; `github-actions` header `Severity` → `Impact`. `setup`'s `Purpose` install-guide tables are left as a documented exception (no severity concept), with a one-line note explaining why.
- **Thin `project-structure` skill (C4)** — adds a fenced audit-report template and an explicit Fix step styled after `naming-format`/`tailwind`. Expands its `allowed-tools` to `Read Glob Grep Edit Bash(git:*)` so the Fix step is executable.
- **Dangling E2E reference (C5)** — `testing` no longer routes E2E requests to a nonexistent in-repo skill; it now points at the agent's own browser/E2E tooling and stops.

Complementary to #41: normalization gives the validator a single format to check against. The generated `xcode-skills/` export is untouched.

Closes #46.

https://claude.ai/code/session_0183ouvicBQZssp5Ze7DSo2Y