### PR TITLE
Keep audit and diagnostic skills read-only by default

### DIFF
--- a/skills/github-actions/SKILL.md
+++ b/skills/github-actions/SKILL.md
@@ -12,7 +12,7 @@ agent: general-purpose
 
 Classify the request before acting, and default to read-only when intent is ambiguous or diagnostic:
 
-- **Create mode**: The user explicitly asks to create, add, generate, or scaffold a workflow (or no `.github/workflows/` directory exists *and* the request is to set up CI). Generates workflows and pins actions per `rules/action-pinning.md` (GitHub-owned `actions/*` on version tags, third-party on full commit SHAs).
+- **Create mode**: The user explicitly asks to create, add, generate, scaffold, or set up a workflow, CI, or a CI/CD pipeline (e.g. "set up CI") — regardless of whether a `.github/workflows/` directory already exists. Generates workflows and pins actions per `rules/action-pinning.md` (GitHub-owned `actions/*` on version tags, third-party on full commit SHAs).
 - **Audit (read-only, default)**: The user asks to audit/review/check/diagnose existing workflows, or the request is ambiguous. Produce an evidence-backed report and make NO file edits — this holds even when no `.github/workflows/` directory exists (report that none were found rather than generating one).
 - **Fix**: The user explicitly asks to fix, pin, apply, or says "audit and fix". Only then apply the scoped edits in Audit Mode's Auto-Fix step.
 

--- a/skills/github-actions/SKILL.md
+++ b/skills/github-actions/SKILL.md
@@ -10,9 +10,13 @@ agent: general-purpose
 
 ## Mode Detection
 
-Determine the mode based on context:
-- **Create mode**: No `.github/workflows/` directory exists, or user explicitly asks to create/add a workflow
-- **Audit mode**: `.github/workflows/*.yml` files exist, or user explicitly asks to audit/review/fix workflows
+Classify the request before acting, and default to read-only when intent is ambiguous or diagnostic:
+
+- **Create mode**: No `.github/workflows/` directory exists, or the user explicitly asks to create/add a workflow. Generates workflows and resolves every action reference to a full commit SHA.
+- **Audit (read-only, default)**: `.github/workflows/*.yml` files exist and the user asks to audit/review/check, or the request is ambiguous. Produce an evidence-backed report and make NO file edits.
+- **Fix**: The user explicitly asks to fix, pin, apply, or says "audit and fix". Only then apply the scoped edits in Audit Mode's Auto-Fix step.
+
+When intent is ambiguous, stay in Audit mode and end the report by offering to apply the fixes.
 
 ---
 
@@ -37,6 +41,8 @@ Scan for project indicators:
 ### 3. Generate Workflow
 
 Apply all rules from the `rules/` directory when generating workflows. Read each rule file for detailed requirements and examples.
+
+Resolve every action reference (including the `actions/*` uses in the template below) to a full commit SHA with a version comment before writing the workflow. Look up SHAs with `gh api`.
 
 ### 4. Workflow Template
 
@@ -99,9 +105,9 @@ Read all files in `.github/workflows/*.yml` and audit against every rule in the 
 - Files scanned: N
 ```
 
-### 3. Auto-Fix
+### 3. Auto-Fix (fix mode only)
 
-After reporting, apply fixes. Look up commit SHAs for pinning using `gh api`.
+Skip this step entirely in Audit mode — report the pinning and permission violations only. Only apply fixes when the request is in Fix mode (see Mode Detection). When fixing, look up commit SHAs for pinning using `gh api`.
 
 ---
 

--- a/skills/github-actions/SKILL.md
+++ b/skills/github-actions/SKILL.md
@@ -12,8 +12,8 @@ agent: general-purpose
 
 Classify the request before acting, and default to read-only when intent is ambiguous or diagnostic:
 
-- **Create mode**: No `.github/workflows/` directory exists, or the user explicitly asks to create/add a workflow. Generates workflows and resolves every action reference to a full commit SHA.
-- **Audit (read-only, default)**: `.github/workflows/*.yml` files exist and the user asks to audit/review/check, or the request is ambiguous. Produce an evidence-backed report and make NO file edits.
+- **Create mode**: The user explicitly asks to create, add, generate, or scaffold a workflow (or no `.github/workflows/` directory exists *and* the request is to set up CI). Generates workflows and pins actions per `rules/action-pinning.md` (GitHub-owned `actions/*` on version tags, third-party on full commit SHAs).
+- **Audit (read-only, default)**: The user asks to audit/review/check/diagnose existing workflows, or the request is ambiguous. Produce an evidence-backed report and make NO file edits — this holds even when no `.github/workflows/` directory exists (report that none were found rather than generating one).
 - **Fix**: The user explicitly asks to fix, pin, apply, or says "audit and fix". Only then apply the scoped edits in Audit Mode's Auto-Fix step.
 
 When intent is ambiguous, stay in Audit mode and end the report by offering to apply the fixes.
@@ -42,7 +42,7 @@ Scan for project indicators:
 
 Apply all rules from the `rules/` directory when generating workflows. Read each rule file for detailed requirements and examples.
 
-Resolve every action reference (including the `actions/*` uses in the template below) to a full commit SHA with a version comment before writing the workflow. Look up SHAs with `gh api`.
+Pin actions per `rules/action-pinning.md` before writing the workflow: GitHub-owned `actions/*` stay on version tags (e.g. `@v4`); third-party actions pin to a full commit SHA with a version comment. Look up SHAs with `gh api`.
 
 ### 4. Workflow Template
 
@@ -107,7 +107,7 @@ Read all files in `.github/workflows/*.yml` and audit against every rule in the 
 
 ### 3. Auto-Fix (fix mode only)
 
-Skip this step entirely in Audit mode — report the pinning and permission violations only. Only apply fixes when the request is in Fix mode (see Mode Detection). When fixing, look up commit SHAs for pinning using `gh api`.
+Skip this step entirely in Audit mode — report **all** rule violations found in the audit (pinning, permissions, concurrency, node version, caching, triggers, and matrix), not just pinning and permissions. Only apply fixes when the request is in Fix mode (see Mode Detection). When fixing, look up commit SHAs for pinning using `gh api`.
 
 ---
 

--- a/skills/naming-format/SKILL.md
+++ b/skills/naming-format/SKILL.md
@@ -25,7 +25,7 @@ Read individual rule files in `rules/` for detailed explanations and examples.
 Classify the request before acting, and default to read-only when intent is ambiguous or diagnostic:
 
 - **Audit (read-only, default)** — "audit", "review", "check", "diagnose", or any unclear request. Produce an evidence-backed report and make NO file edits or renames.
-- **Fix** — the user explicitly asks to fix, rename, apply, or says "audit and fix". Only then apply the renames and import updates in the Fix step.
+- **Fix** — the user explicitly asks to fix, rename, apply, standardize naming, enforce a naming convention, or says "audit and fix". Only then apply the renames and import updates in the Fix step.
 
 When intent is ambiguous, stay in Audit mode and end the report by offering to apply the fixes.
 

--- a/skills/naming-format/SKILL.md
+++ b/skills/naming-format/SKILL.md
@@ -20,6 +20,15 @@ Read individual rule files in `rules/` for detailed explanations and examples.
 | Index files | HIGH | `rules/index-files.md` |
 | Framework conventions | MEDIUM | `rules/framework-conventions.md` |
 
+## Mode Detection
+
+Classify the request before acting, and default to read-only when intent is ambiguous or diagnostic:
+
+- **Audit (read-only, default)** — "audit", "review", "check", "diagnose", or any unclear request. Produce an evidence-backed report and make NO file edits or renames.
+- **Fix** — the user explicitly asks to fix, rename, apply, or says "audit and fix". Only then apply the renames and import updates in the Fix step.
+
+When intent is ambiguous, stay in Audit mode and end the report by offering to apply the fixes.
+
 ## Workflow
 
 ### Step 1: Detect
@@ -53,7 +62,9 @@ Check all files and exports against the rules. Report violations grouped by rule
 | **Total**         | **X+Y**    | **N** |
 ```
 
-### Step 3: Fix
+### Step 3: Fix (fix mode only)
+
+Skip this step entirely in Audit mode. Only apply renames when the request is in Fix mode (see Mode Detection).
 
 Apply fixes for each violation:
 1. Rename files using `git mv` to preserve git history

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -20,6 +20,15 @@ Read individual rule files in `rules/` for detailed explanations and code exampl
 | TypeScript/JS Idioms | `ts-` | type-assertions, optional-chaining, nullish-coalescing, barrel-reexports, enum-union, async-await |
 | Design Principles | `design-` | single-responsibility, interface-segregation, god-objects, tight-coupling |
 
+## Mode Detection
+
+Classify the request before acting, and default to read-only when intent is ambiguous or diagnostic:
+
+- **Audit (read-only, default)** — "audit", "review", "check", "clean up review", or any unclear request. Produce an evidence-backed report and make NO file edits.
+- **Fix** — the user explicitly asks to fix, refactor, apply, clean up, or says "audit and fix". Only then apply the scoped changes in the Fix step.
+
+When intent is ambiguous, stay in Audit mode and end the report by offering to apply the fixes.
+
 ## Workflow
 
 ### Step 1: Audit
@@ -73,7 +82,9 @@ List all findings grouped by category:
 | **Total**            | **X+Y+Z** | **N** |
 ```
 
-### Step 3: Fix
+### Step 3: Fix (fix mode only)
+
+Skip this step entirely in Audit mode. Only apply changes when the request is in Fix mode (see Mode Detection).
 
 Apply refactorings. For each fix:
 1. Verify the change preserves existing behaviour

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -25,7 +25,7 @@ Read individual rule files in `rules/` for detailed explanations and code exampl
 Classify the request before acting, and default to read-only when intent is ambiguous or diagnostic:
 
 - **Audit (read-only, default)** — "audit", "review", "check", "clean up review", or any unclear request. Produce an evidence-backed report and make NO file edits.
-- **Fix** — the user explicitly asks to fix, refactor, apply, clean up, or says "audit and fix". Only then apply the scoped changes in the Fix step.
+- **Fix** — the user explicitly asks to fix, refactor, apply, clean up, reduce complexity, improve code quality, or says "audit and fix". Only then apply the scoped changes in the Fix step.
 
 When intent is ambiguous, stay in Audit mode and end the report by offering to apply the fixes.
 

--- a/skills/security/SKILL.md
+++ b/skills/security/SKILL.md
@@ -22,20 +22,22 @@ Read individual rule files in `rules/` for detailed explanations and examples.
 | Insecure dependencies | MEDIUM | `rules/insecure-dependencies.md` |
 | Data protection | MEDIUM | `rules/data-protection.md` |
 
+## Mode Detection
+
+Classify the request before acting, and default to read-only when intent is ambiguous or diagnostic:
+
+- **Audit (read-only, default)** — "audit", "review", "check", "scan", "diagnose", or any unclear request. Produce an evidence-backed report and make NO file edits. Read-only scans (including `gitleaks detect`) are allowed; setting up hooks or editing code is not.
+- **Fix** — the user explicitly asks to fix, set up, harden, apply, or says "audit and fix". Only then run the GitLeaks Setup and any remediation steps.
+
+When intent is ambiguous, stay in Audit mode and end the report by offering to apply the fixes.
+
 ## Workflow
 
-### Step 1: GitLeaks Setup
+### Step 1: Code Security Audit
 
-Ensure GitLeaks is configured in the project's pre-commit hook:
+Scan the codebase against every rule in `rules/`. Search for vulnerability patterns. In Audit mode, also check whether GitLeaks is wired into the pre-commit hook (does `.husky/pre-commit` exist and contain `gitleaks`?) and report it as a finding if missing — but do not modify any files.
 
-1. Check if `.husky/pre-commit` exists and contains `gitleaks`
-2. If missing, set up Husky and add `gitleaks protect --staged --verbose` before any `lint-staged` command
-
-### Step 2: Code Security Audit
-
-Scan the codebase against every rule in `rules/`. Search for vulnerability patterns.
-
-### Step 3: Report
+### Step 2: Report
 
 ```
 ## Security Audit Results
@@ -54,13 +56,22 @@ Scan the codebase against every rule in `rules/`. Search for vulnerability patte
 | **Total** | **Z** |
 ```
 
-### Step 4: Retrospective History Scan (Optional)
+### Step 3: Retrospective History Scan (Optional)
 
-Only when user passes `--scan-history`:
+Only when user passes `--scan-history`. This is a read-only scan, allowed in either mode:
 
 ```bash
 gitleaks detect --source . --verbose
 ```
+
+### Step 4: GitLeaks Setup (fix mode only)
+
+Skip this step entirely in Audit mode. Only run it when the request is in Fix mode (see Mode Detection).
+
+Ensure GitLeaks is configured in the project's pre-commit hook:
+
+1. Check if `.husky/pre-commit` exists and contains `gitleaks`
+2. If missing, set up Husky and add `gitleaks protect --staged --verbose` before any `lint-staged` command
 
 ## Assumptions
 

--- a/skills/tailwind/SKILL.md
+++ b/skills/tailwind/SKILL.md
@@ -23,6 +23,15 @@ Read individual rule files in `rules/` for detailed explanations and code exampl
 | Logical shorthands | MEDIUM | `rules/logical-shorthands.md` |
 | GPU-accelerated animations | MEDIUM | `rules/gpu-animations.md` |
 
+## Mode Detection
+
+Classify the request before acting, and default to read-only when intent is ambiguous or diagnostic:
+
+- **Audit (read-only, default)** — "audit", "review", "check", "diagnose", or any unclear request. Produce an evidence-backed report and make NO file edits.
+- **Fix** — the user explicitly asks to fix, change, apply, clean up, or says "audit and fix". Only then apply the scoped changes in the Fix step.
+
+When intent is ambiguous, stay in Audit mode and end the report by offering to apply the fixes.
+
 ## Workflow
 
 ### Step 1: Audit
@@ -58,7 +67,9 @@ List all findings grouped by rule:
 | **Total** | **Z** | **N** |
 ```
 
-### Step 3: Fix
+### Step 3: Fix (fix mode only)
+
+Skip this step entirely in Audit mode. Only apply changes when the request is in Fix mode (see Mode Detection).
 
 Apply fixes. For each fix:
 1. Verify the change preserves visual appearance

--- a/skills/tailwind/SKILL.md
+++ b/skills/tailwind/SKILL.md
@@ -28,7 +28,7 @@ Read individual rule files in `rules/` for detailed explanations and code exampl
 Classify the request before acting, and default to read-only when intent is ambiguous or diagnostic:
 
 - **Audit (read-only, default)** — "audit", "review", "check", "diagnose", or any unclear request. Produce an evidence-backed report and make NO file edits.
-- **Fix** — the user explicitly asks to fix, change, apply, clean up, or says "audit and fix". Only then apply the scoped changes in the Fix step.
+- **Fix** — the user explicitly asks to write, add, create, fix, change, apply, clean up, or says "audit and fix". Only then apply the scoped changes in the Fix step.
 
 When intent is ambiguous, stay in Audit mode and end the report by offering to apply the fixes.
 

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -22,8 +22,8 @@ Determine the test type from the user's request:
 Classify the request before acting, and default to read-only when intent is ambiguous or diagnostic:
 
 - **Review (read-only, default)** — "review", "audit", "check", or "assess" test quality or coverage. Read the tests and source, then produce an evidence-backed report (gaps, weak assertions, missing edge cases) and make NO file edits. Skip Steps 4-5.
-- **Run** — the user explicitly asks to run or execute the existing tests. Run Step 5 (run and verify) and report the results; do not write new tests unless also asked.
-- **Write / Fix** — the user explicitly asks to write, add, create, or fix tests, or to debug failing tests. Run Step 4 (write test files) and Step 5 (run and verify). Running tests to observe failures is allowed in this mode.
+- **Run** — the user explicitly asks to run or execute the existing tests. Run Step 5 (run and verify) and report the results; do not write new tests or edit failing ones unless also asked.
+- **Write / Fix** — the user explicitly asks to write, add, create, or fix tests, to debug failing tests, or to increase/improve coverage or cover edge cases. Run Step 4 (write test files) and Step 5 (run and verify). Running tests to observe failures, then editing tests, is allowed in this mode.
 
 When intent is ambiguous, stay in Review mode and end the report by offering to write or run the tests.
 
@@ -82,7 +82,7 @@ pnpm run test          # or npm/bun/yarn equivalent
 pnpm vitest run <file> # run a specific test file
 ```
 
-Report results. If tests fail, read the error output, fix the test, and re-run.
+Report results. In **Write / Fix** mode only, if tests fail, read the error output, fix the test, and re-run. In **Run** mode, report the failures without editing any files.
 
 ## Assumptions
 

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -22,9 +22,10 @@ Determine the test type from the user's request:
 Classify the request before acting, and default to read-only when intent is ambiguous or diagnostic:
 
 - **Review (read-only, default)** — "review", "audit", "check", or "assess" test quality or coverage. Read the tests and source, then produce an evidence-backed report (gaps, weak assertions, missing edge cases) and make NO file edits. Skip Steps 4-5.
-- **Write / Fix** — the user explicitly asks to write, add, create, or fix tests, or to debug failing tests. Only then run Step 4 (write test files) and Step 5 (run and verify). Running tests to observe failures is allowed in this mode.
+- **Run** — the user explicitly asks to run or execute the existing tests. Run Step 5 (run and verify) and report the results; do not write new tests unless also asked.
+- **Write / Fix** — the user explicitly asks to write, add, create, or fix tests, or to debug failing tests. Run Step 4 (write test files) and Step 5 (run and verify). Running tests to observe failures is allowed in this mode.
 
-When intent is ambiguous, stay in Review mode and end the report by offering to write the tests.
+When intent is ambiguous, stay in Review mode and end the report by offering to write or run the tests.
 
 ## Rules Overview
 

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -17,6 +17,15 @@ Determine the test type from the user's request:
 - **E2E / browser testing** (keywords: "e2e", "end-to-end", "browser", "playwright", "page interaction", "screenshot") → Tell the user to use a browser/E2E testing skill instead and stop.
 - **Unit / component testing** → Proceed with the workflow below.
 
+## Mode Detection
+
+Classify the request before acting, and default to read-only when intent is ambiguous or diagnostic:
+
+- **Review (read-only, default)** — "review", "audit", "check", or "assess" test quality or coverage. Read the tests and source, then produce an evidence-backed report (gaps, weak assertions, missing edge cases) and make NO file edits. Skip Steps 4-5.
+- **Write / Fix** — the user explicitly asks to write, add, create, or fix tests, or to debug failing tests. Only then run Step 4 (write test files) and Step 5 (run and verify). Running tests to observe failures is allowed in this mode.
+
+When intent is ambiguous, stay in Review mode and end the report by offering to write the tests.
+
 ## Rules Overview
 
 | Rule | Impact | File |


### PR DESCRIPTION
Several skills combined audit and fix behaviour, so an audit/review/check/diagnose request could slide straight into editing files the user never authorised changing.

This introduces an explicit **Mode Detection** step across `refactor`, `security`, `naming-format`, `github-actions`, `tailwind`, and `testing` that classifies intent and makes read-only the safe default whenever the request is diagnostic or ambiguous. Fix, create, and "audit and fix" workflows are preserved, but their mutating steps are now gated behind explicit fix/create intent — including `github-actions`, where audit mode only reports pinning violations while create mode resolves action references to full commit SHAs.

The mode-detection wording is reused across all six skills so they read as one system. `allowed-tools` needed no changes (each skill already declares a superset covering all its modes); `context: fork` frontmatter is intact; the `xcode-skills/` export is untouched.

Closes #40.

https://claude.ai/code/session_0183ouvicBQZssp5Ze7DSo2Y