### PR TITLE
Address Codex review comments from PR #53

### DIFF
--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -27,7 +27,7 @@ Read ALL rule files before proceeding — do not skip or ask:
 
 Scan staged changes for secrets before every commit, using the project's secret scanner. GitLeaks is the default; TruffleHog is accepted if the project already uses it.
 
-1. Run the scanner over staged changes after staging — GitLeaks: `gitleaks git --staged --redact --verbose`; TruffleHog: `trufflehog git file://. --since-commit HEAD --only-verified --fail`.
+1. Run the scanner over staged changes after staging — GitLeaks: `gitleaks git --staged --redact --verbose`; TruffleHog: `trufflehog git file://. --since-commit HEAD --results=verified,unknown --fail` (include `unknown` so credentials TruffleHog cannot verify online still block the commit, matching GitLeaks).
 2. If the scanner reports a leak, **STOP** — do not commit. Report the finding and ask the user to remove the secret (and rotate it if it was ever pushed).
 3. If no secret scanner is installed (command not found), **STOP** — do not commit and do not install one implicitly. Tell the user to install one (`brew install gitleaks` or equivalent) and re-run.
 

--- a/skills/create-pr/SKILL.md
+++ b/skills/create-pr/SKILL.md
@@ -23,6 +23,8 @@ Read individual rule files in `rules/` for detailed requirements and examples.
 1. Check current git status and branch
 2. Push current branch to remote (with `-u` flag if needed)
 3. Analyse recent commits to generate PR title and description
-4. Detect the remote host from `git remote get-url origin` (github.com → gh, gitlab.com → glab; default GitHub) and create the PR/MR with the matching CLI — GitHub: `gh pr create --assignee @me`; GitLab: `glab mr create --assignee @me`. The body is concise bullet points only (no `## Summary`, `## Test Plan`, checklists, or other heading sections)
+4. Detect the remote host from `git remote get-url origin` (github.com → gh, gitlab.com → glab; default GitHub) and create the PR/MR with the matching CLI. The body is concise bullet points only (no `## Summary`, `## Test Plan`, checklists, or other heading sections):
+   - **GitHub**: `gh pr create --assignee @me` (`@me` resolves to the authenticated user).
+   - **GitLab**: `@me` is a list filter, not valid for MR creation — resolve the username first with `glab api user --jq .username`, then `glab mr create --assignee <username>`.
 
-Auto-assign to current user via `--assignee @me`. If assignment fails (user not a collaborator), the PR/MR is still created without assignment.
+Auto-assign to the current user. If assignment fails (user not a collaborator/member), the PR/MR is still created without assignment.

--- a/skills/deps/references/python.md
+++ b/skills/deps/references/python.md
@@ -14,21 +14,25 @@ Dependency supply-chain hardening for Python projects — the ecosystem equivale
 
 ## 1. Pin Exact Versions
 
-Pin direct dependencies to exact versions so builds are reproducible and updates flow through reviewable PRs (the analogue of removing `^`/`~` in `package.json`).
+Pin direct dependencies to exact versions so builds are reproducible and updates flow through reviewable PRs (the analogue of removing `^`/`~` in `package.json`). **Where** you pin depends on whether the project is an application or a published library — detect this first.
 
-Incorrect (`pyproject.toml`):
+**App vs. library:**
+- **Library** (published to PyPI / installed by others as a package — typically has a build backend under `[build-system]` and is `pip install`-able): keep **compatible bounds** in `pyproject.toml` `dependencies`, and pin exact versions only in the lockfile (`uv.lock` / `poetry.lock`) or a compiled `requirements.txt`. Exact `==` pins in library metadata force those versions on every consumer and cause resolver conflicts.
+- **App / deployed service** (not published for others to install): pin exact versions directly in `pyproject.toml` for a fully reproducible environment.
+
+Library metadata — keep bounds (`pyproject.toml`):
 
 ```toml
-dependencies = ["requests>=2.31", "pydantic~=2.5"]
+dependencies = ["requests>=2.31,<3", "pydantic~=2.5"]
 ```
 
-Correct:
+App — pin exact (`pyproject.toml`):
 
 ```toml
 dependencies = ["requests==2.31.0", "pydantic==2.5.3"]
 ```
 
-For pip projects, compile a fully pinned, hashed lockfile from a loose `requirements.in`:
+For libraries (and pip-based apps), compile a fully pinned, hashed lockfile from the abstract requirements — this is where the exact pins live:
 
 ```bash
 uv pip compile requirements.in -o requirements.txt --generate-hashes

--- a/skills/github-issues/SKILL.md
+++ b/skills/github-issues/SKILL.md
@@ -23,7 +23,7 @@ Read individual rule files in `rules/` for detailed requirements and examples.
 
 1. Determine action: create, update, query, or comment
 2. Detect the remote host from `git remote get-url origin` (github.com → gh, gitlab.com → glab; default GitHub) and use that CLI throughout. Get owner/repo (or group/project) info. **GitHub-only features** — organisation issue types, sub-issues, and `.github/ISSUE_TEMPLATE/` — do not exist on GitLab: on GitLab skip the issue-type and sub-issue steps and use `.gitlab/issue_templates/` plus description checklists instead
-3. Check for issue templates in `.github/ISSUE_TEMPLATE/` or `.github/`
+3. Check for issue templates in the host's conventional location: on GitHub `.github/ISSUE_TEMPLATE/` or `.github/`; on GitLab `.gitlab/issue_templates/`
 4. List available organisation issue types (fails for user-owned repos — expected, proceed without)
 5. For creation or update:
    - For updates: fetch the current issue first

--- a/skills/security/SKILL.md
+++ b/skills/security/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: security
 description: Use when auditing security, checking for vulnerabilities, scanning for secrets, or reviewing dependencies. OWASP Top 10 audit with GitLeaks and dependency checks.
-allowed-tools: Read Glob Grep Edit Bash(gitleaks:*) Bash(trufflehog:*) Bash(pnx:*) Bash(npm:*)
+allowed-tools: Read Glob Grep Edit Bash(gitleaks:*) Bash(trufflehog:*) Bash(pnx:*) Bash(npm:*) Bash(pip-audit:*) Bash(govulncheck:*) Bash(go:*)
 model: sonnet
 effort: high
 context: fork

--- a/skills/security/rules/insecure-dependencies.md
+++ b/skills/security/rules/insecure-dependencies.md
@@ -1,31 +1,34 @@
 ---
 title: Insecure Dependencies
 impact: MEDIUM
-tags: dependencies, audit, npm, pnpm, yarn, bun, vulnerabilities
+tags: dependencies, audit, npm, pnpm, yarn, bun, pip, go, vulnerabilities
 ---
 
-**Rule**: Check for known vulnerabilities in project dependencies.
+**Rule**: Check for known vulnerabilities in project dependencies. Use the auditor for the project's ecosystem — detect the language from its manifest (`package.json` / `pyproject.toml` / `go.mod`) and run the matching tool. Auditing only npm on a Python or Go project silently misses CVEs.
 
 ### How to Audit
 
+**JS/TS** (match the package manager):
+
 ```bash
-# npm
-npm audit
-
-# pnpm
-pnpm audit
-
-# yarn
-yarn audit
-
-# bun
-bun audit
+npm audit        # or: pnpm audit / yarn audit / bun audit
 
 # Check for outdated packages
-npm outdated
-pnpm outdated
-yarn outdated
-bun outdated
+npm outdated     # or: pnpm outdated / yarn outdated / bun outdated
+```
+
+**Python** — `pip-audit`:
+
+```bash
+pip-audit                       # audit the current environment
+pip-audit -r requirements.txt   # audit a requirements file
+```
+
+**Go** — `govulncheck` (from golang.org/x/vuln):
+
+```bash
+govulncheck ./...   # reports only vulnerabilities reachable from your code
+go list -m -u all   # show available module updates
 ```
 
 ### What to Check

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: setup
 description: Use when setting up a project, adding linting, formatting, git hooks, or type checking. Detects the language and installs that ecosystem's lint/format/hooks toolchain (JS/TS, Python, Go).
-allowed-tools: Read Glob Write Edit Bash(pnpm:*) Bash(pnx:*) Bash(npm:*) Bash(bun:*) Bash(yarn:*) Bash(uv:*) Bash(poetry:*) Bash(pip:*) Bash(ruff:*) Bash(go:*) Bash(golangci-lint:*) Bash(pre-commit:*)
+allowed-tools: Read Glob Write Edit Bash(pnpm:*) Bash(pnx:*) Bash(npm:*) Bash(bun:*) Bash(yarn:*) Bash(uv:*) Bash(poetry:*) Bash(pdm:*) Bash(pip:*) Bash(ruff:*) Bash(mypy:*) Bash(go:*) Bash(gofmt:*) Bash(goimports:*) Bash(golangci-lint:*) Bash(pre-commit:*)
 model: haiku
 effort: low
 compatibility: Any language project; sets up that ecosystem's lint/format/hooks + git secret scanning (JS/TS best-supported, Python and Go via references/)

--- a/skills/testing/rules/js-runner-patterns.md
+++ b/skills/testing/rules/js-runner-patterns.md
@@ -12,11 +12,13 @@ tags: vitest, jest, node-test, mocking, setup, teardown, globals
 |---|---|---|---|
 | Mock namespace | `vi` | `jest` | `mock` (from `node:test`) |
 | Standalone mock | `vi.fn()` | `jest.fn()` | `mock.fn()` |
-| Module mock | `vi.mock()` | `jest.mock()` | `mock.module()` |
+| Module mock | `vi.mock()` | `jest.mock()` | `mock.module()` † |
 | Assertions | `expect` (built-in) | `expect` (built-in) | `node:assert` |
 | Globals without import | `globals: true` | on by default | never — import from `node:test` |
 
 Match whichever runner the project already uses (see Config Detection below). Do not introduce a second runner.
+
+† **node:test module mocking is experimental.** `mock.module()` only works when Node is started with `--experimental-test-module-mocks` (e.g. `node --test --experimental-test-module-mocks`). Add that flag to the project's test command when generating module mocks, or avoid module-level mocks (prefer dependency injection or `mock.fn()`) so a plain `node --test` script doesn't fail.
 
 ### Globals Mode
 


### PR DESCRIPTION
Follow-up to the merged platform-agnostic pass (#53), addressing the 7 Codex review comments (1×P1, 6×P2) — each was a real gap where a skill claimed multi-language/multi-host support but the flag, command, or tool grant was still JS/TS- or GitHub-only.

- **commit** (P1): TruffleHog pre-commit now uses `--results=verified,unknown --fail` instead of `--only-verified`, so unverifiable credentials still block the commit (matching GitLeaks)
- **setup**: grant `pdm`, `mypy`, `gofmt`, `goimports` in `allowed-tools` — the Python/Go guides invoke them
- **create-pr**: GitLab MRs resolve the username via `glab api user` before `--assignee` (`@me` is a GitLab list filter, not valid for MR creation); GitHub keeps `--assignee @me`
- **testing**: note that node:test `mock.module()` requires launching Node with `--experimental-test-module-mocks`
- **github-issues**: template discovery is host-aware — `.gitlab/issue_templates/` on GitLab, `.github/ISSUE_TEMPLATE/` on GitHub
- **deps** (Python): pin exact versions only for apps; libraries keep compatible bounds in `pyproject.toml` and pin the lockfile instead
- **security**: dependency-audit rule extended to Python (`pip-audit`) and Go (`govulncheck`) with matching tool grants, so non-JS audits no longer miss CVEs