### PR TITLE
Pause OpenCode plugin support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ A collection of agent skills distributed via Codex, Claude Code, Cursor, Antigra
 
 - **Package manager:** pnpm (v10.29.3)
 - **Git hooks:** Husky with commitlint (conventional commits via `@commitlint/config-conventional`) and GitLeaks secrets detection on pre-commit
-- **Checks:** `pnpm run build` and `pnpm run check`
+- **Checks:** `pnpm run build`, `pnpm run check`, `pnpm run validate`, and `pnpm test`
 - **Releases:** Automated via release-please on push to `main` — maintains a release PR from conventional commits; merging it bumps versions, updates `CHANGELOG.md`, and creates the GitHub release
 
 ## Skill Format

--- a/README.md
+++ b/README.md
@@ -160,16 +160,7 @@ pnpm dlx ctx7 skills install /tartinerlabs/skills --all --universal
 
 ### [OpenCode](https://opencode.ai)
 
-> **Note:** The OpenCode plugin is currently in Beta and might not work.
-
-Add to `opencode.json`:
-
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "plugin": ["@tartinerlabs/skills"]
-}
-```
+> **Note:** The OpenCode plugin is paused — OpenCode's TypeScript plugin system differs too much from the manifest-based Claude Code/Codex/Cursor plugins to maintain alongside them. The plugin source stays in the repository, but no further versions of the `@tartinerlabs/skills` npm package will be published. OpenCode users can install the skills directly via [skills.sh](#skills), which copies them into OpenCode's skill discovery directories.
 
 ## Plugin Metadata
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tartinerlabs/skills",
   "version": "1.29.0",
+  "private": true,
   "description": "Language-agnostic agent skills for git/GitHub workflows, code quality, and project tooling, with first-class JS/TS support",
   "author": "ruchern.chong@tartinerlabs.com",
   "license": "MIT",


### PR DESCRIPTION
- Pause the OpenCode plugin without removing it — the source (`src/index.ts`, `.opencode/`, `tsconfig.json`), the `@opencode-ai/plugin` dependency, and the `tsc` build step all stay in place so the code keeps building
- Mark the package `"private": true` so no further versions of the `@tartinerlabs/skills` npm package are published
- Replace the OpenCode install instructions in the README with a pause note pointing users at skills.sh, which copies skills into OpenCode's discovery directories
- Document the full check suite (`build`, `check`, `validate`, `test`) in AGENTS.md

Stacked on #60 — merge that first; GitHub will retarget this to `main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tartinerlabs/codesmith/skills/pr/61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787390505&installation_model_id=427837&pr_number=61&repository=tartinerlabs%2Fskills&return_to=https%3A%2F%2Fgithub.com%2Ftartinerlabs%2Fskills%2Fpull%2F61&signature=d43458be95a2c95e8db4fab1c1fb961da05d0f04edadb15258b6697f5233f22f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
