### PR TITLE
Capitalise plugin display names

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "tartinerlabs",
   "interface": {
-    "displayName": "tartiner-labs"
+    "displayName": "Tartiner Labs"
   },
   "plugins": [
     {

--- a/plugins/quality/.codex-plugin/plugin.json
+++ b/plugins/quality/.codex-plugin/plugin.json
@@ -17,7 +17,7 @@
   ],
   "skills": "./skills/",
   "interface": {
-    "displayName": "quality",
+    "displayName": "Quality",
     "shortDescription": "Code quality and refactoring skills.",
     "developerName": "Tartiner Labs",
     "category": "Coding",

--- a/plugins/security/.codex-plugin/plugin.json
+++ b/plugins/security/.codex-plugin/plugin.json
@@ -17,7 +17,7 @@
   ],
   "skills": "./skills/",
   "interface": {
-    "displayName": "security",
+    "displayName": "Security",
     "shortDescription": "Security and supply-chain skills.",
     "developerName": "Tartiner Labs",
     "category": "Coding",

--- a/plugins/tartinerlabs/.antigravity-plugin/plugin.json
+++ b/plugins/tartinerlabs/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tartinerlabs",
-  "displayName": "tartiner-labs (deprecated)",
+  "displayName": "Tartiner Labs (deprecated)",
   "version": "1.30.0",
   "description": "Deprecated: install the workflow, quality, security, and tooling plugins instead. Language-agnostic agent skills for git/GitHub workflows, code quality, and project tooling, with first-class JS/TS support.",
   "author": {

--- a/plugins/tartinerlabs/.claude-plugin/plugin.json
+++ b/plugins/tartinerlabs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tartinerlabs",
-  "displayName": "tartiner-labs (deprecated)",
+  "displayName": "Tartiner Labs (deprecated)",
   "version": "1.30.0",
   "description": "Deprecated: install the workflow, quality, security, and tooling plugins instead. Language-agnostic agent skills for git/GitHub workflows, code quality, and project tooling, with first-class JS/TS support.",
   "author": {

--- a/plugins/tartinerlabs/.codex-plugin/plugin.json
+++ b/plugins/tartinerlabs/.codex-plugin/plugin.json
@@ -25,7 +25,7 @@
   ],
   "skills": "./skills/",
   "interface": {
-    "displayName": "tartiner-labs (deprecated)",
+    "displayName": "Tartiner Labs (deprecated)",
     "shortDescription": "Deprecated — use the workflow, quality, security, and tooling plugins.",
     "developerName": "Tartiner Labs",
     "category": "Coding",

--- a/plugins/tartinerlabs/.cursor-plugin/plugin.json
+++ b/plugins/tartinerlabs/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tartinerlabs",
-  "displayName": "tartiner-labs (deprecated)",
+  "displayName": "Tartiner Labs (deprecated)",
   "version": "1.30.0",
   "description": "Deprecated: install the workflow, quality, security, and tooling plugins instead. Language-agnostic agent skills for git/GitHub workflows, code quality, and project tooling, with first-class JS/TS support.",
   "author": {

--- a/plugins/tooling/.codex-plugin/plugin.json
+++ b/plugins/tooling/.codex-plugin/plugin.json
@@ -18,7 +18,7 @@
   ],
   "skills": "./skills/",
   "interface": {
-    "displayName": "tooling",
+    "displayName": "Tooling",
     "shortDescription": "Project setup, testing, and docs skills.",
     "developerName": "Tartiner Labs",
     "category": "Coding",

--- a/plugins/workflow/.codex-plugin/plugin.json
+++ b/plugins/workflow/.codex-plugin/plugin.json
@@ -20,7 +20,7 @@
   ],
   "skills": "./skills/",
   "interface": {
-    "displayName": "workflow",
+    "displayName": "Workflow",
     "shortDescription": "Git and GitHub workflow skills.",
     "developerName": "Tartiner Labs",
     "category": "Coding",

--- a/plugins/xcode-skills/.codex-plugin/plugin.json
+++ b/plugins/xcode-skills/.codex-plugin/plugin.json
@@ -18,7 +18,7 @@
   ],
   "skills": "./skills/",
   "interface": {
-    "displayName": "xcode-skills",
+    "displayName": "Xcode Skills",
     "shortDescription": "Apple-authored skills exported unchanged from Xcode 27.",
     "longDescription": "Use Apple's exported Xcode 27 guidance for SwiftUI, UIKit modernization, Swift Testing, device verification, C bounds safety, and Xcode security settings.",
     "developerName": "Tartiner Labs",


### PR DESCRIPTION
## What changed

Capitalises the human-facing `displayName` fields across the plugin manifests:

- **Codex manifests** (`plugins/*/.codex-plugin/plugin.json`): `workflow` → `Workflow`, `quality` → `Quality`, `security` → `Security`, `tooling` → `Tooling`, `xcode-skills` → `Xcode Skills`, `tartiner-labs (deprecated)` → `Tartiner Labs (deprecated)`
- **Codex marketplace** (`.agents/plugins/marketplace.json`): marketplace `displayName` `tartiner-labs` → `Tartiner Labs`
- **Deprecated plugin's other channel manifests** (`.claude-plugin`, `.cursor-plugin`, `.antigravity-plugin`): `tartiner-labs (deprecated)` → `Tartiner Labs (deprecated)` for consistency

## Why

Display names are user-facing UI labels, not identifiers — they should read as proper names rather than lowercase slugs. All `name` fields (the actual identifiers) stay lowercase and unchanged, so installs and skill invocations are unaffected.

## Notes for reviewers

`go run ./scripts/validate-skills` passes; no versions or descriptions were touched, so there's no conflict with release-please's manifest syncing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tartinerlabs/codesmith/skills/pr/67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787400754&installation_model_id=427837&pr_number=67&repository=tartinerlabs%2Fskills&return_to=https%3A%2F%2Fgithub.com%2Ftartinerlabs%2Fskills%2Fpull%2F67&signature=bd8c3611bd2de81b27f03d5837c87360106bfee6a669c83cbe188aefe5283369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->