### PR TITLE
Document Agent Plugins packaging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ A collection of agent skills distributed via Claude Code, Codex, Cursor, Antigra
 
 ## Skill Format
 
-Each skill lives in `skills/<name>/SKILL.md`:
+Each collection skill lives in `plugins/<collection>/skills/<name>/SKILL.md`. The flat `skills/<name>` path is an inbound symlink so skills.sh and whole-directory wrappers keep working:
 
 ```markdown
 ---
@@ -68,15 +68,20 @@ Skills are lightweight guides, not procedures. State a preference and its reason
 
 The skills ship as four themed **collection plugins** — `workflow`, `quality`, `security`, and `tooling`. The original all-in-one `tartinerlabs` plugin is **deprecated** but still published for a transition period; its removal is a future release. The `collections` table in `scripts/validate-skills/main.go` is the source of truth for membership — every skill must belong to exactly one collection (validated in CI).
 
-Five channels: Claude Code, Codex, Cursor, and Antigravity plugins (each reading `plugins/<collection>/.<channel>-plugin/plugin.json`), plus [skills.sh](https://skills.sh). `README.md` has the install commands. The `Skills` CI workflow validates skills.sh distribution on push to `main`. Context7 was a sixth channel until `ctx7 skills install` was deprecated upstream with no successor; Context7 remains a documentation source, not a distribution target.
+Cursor and Codex load the portable [Agent Plugins](https://agent-plugins.org) 1.0.0 floor at `plugins/<name>/plugin.json` (Codex UI copy lives in `extensions.com.openai`). Claude Code and Antigravity keep their channel manifests at `plugins/<name>/.claude-plugin/plugin.json` and `plugins/<name>/.antigravity-plugin/plugin.json`. Cursor marketplace listing still uses `.cursor-plugin/plugin.json`. [skills.sh](https://skills.sh) installs from the inbound `skills/<name>` symlinks. `README.md` has the install commands. The `Skills` CI workflow validates skills.sh distribution on push to `main`. Context7 was a sixth channel until `ctx7 skills install` was deprecated upstream with no successor; Context7 remains a documentation source, not a distribution target.
 
 ## Plugins
 
-Plugin metadata is hand-maintained by design — there is no generator. Every plugin lives in its own `plugins/<name>/` wrapper holding its four per-channel manifests plus a `skills` entry exposing its skill source. Two wrapper shapes exist: **collection wrappers** with a real `skills/` directory of per-skill symlinks, and **whole-directory wrappers** (`tartinerlabs`, `xcode-skills`) exposing a source directory through one dir symlink. The validator checks every symlink target.
+Plugin metadata is hand-maintained by design — there is no generator. Every plugin lives in `plugins/<name>/` with a root Agent Plugins `plugin.json` for Cursor and Codex, plus Claude Code and Antigravity channel overlays. Cursor keeps `.cursor-plugin/` for marketplace listing.
+
+Two wrapper shapes exist:
+
+- **collection wrappers** (`workflow`, `quality`, `security`, `tooling`) own the real skill trees at `plugins/<collection>/skills/<skill>/`. The flat `skills/<skill>` path is an inbound symlink into that tree, which is Agent Plugins containment-conformant.
+- **whole-directory wrappers** (`tartinerlabs`, `xcode-skills`) keep a `skills` symlink that escapes the plugin root (`../../skills` and `../../xcode-skills`). They remain non-conformant for Agent Plugins containment. The validator checks every symlink target.
 
 - Each marketplace references every plugin as `./plugins/<name>`. **Keep every plugin subdirectory-sourced** — the Claude Code loader silently drops a plugin sourced at the marketplace root (`source: "./"`) when another plugin exists
 - `.release-please-manifest.json` is the canonical version source; release-please (`extra-files` in `release-please-config.json`) syncs the `plugins/**/plugin.json` versions in the release PR. Never bump a version by hand
-- When plugin copy changes, update all four channels intentionally. Do not expose Claude-only hooks in Cursor or Codex metadata unless they have been ported to that runtime
+- When plugin copy changes, update the root Agent Plugins manifest and the Claude/Cursor/Antigravity overlays intentionally. Codex UI copy lives in `extensions.com.openai.interface` on the root manifest. Do not expose Claude-only hooks in Cursor or Codex metadata unless they have been ported to that runtime
 
 ## Xcode Skill Export
 
@@ -86,7 +91,7 @@ All plugin metadata for this collection belongs in `plugins/xcode-skills/`, whos
 
 ## Conventions
 
-- **Commit type for skill content:** skill markdown (`skills/**/*.md`) is the product, not documentation. Changes to skill behaviour use `feat`/`fix`/`refactor` — never `docs`. Reserve `docs:` for `README.md`, `AGENTS.md`, `CLAUDE.md`, `CHANGELOG.md`, and similar meta-documentation
+- **Commit type for skill content:** skill markdown (`plugins/*/skills/**/*.md`, plus the inbound `skills/**/*.md` aliases) is the product, not documentation. Changes to skill behaviour use `feat`/`fix`/`refactor` — never `docs`. Reserve `docs:` for `README.md`, `AGENTS.md`, `CLAUDE.md`, `CHANGELOG.md`, and similar meta-documentation
 - Commit subjects are max 50 characters with no scope, enforced by `.githooks/commit-msg`
 - PR and issue titles use natural language, NOT conventional commit prefixes
 - GitHub-related skills auto-assign to the current user via `@me` or `get_me`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,32 +30,33 @@ Thanks for your interest in contributing to `@tartinerlabs/skills`! This guide c
 
 ## Skill Structure
 
-Each skill lives in its own directory under `skills/`:
+Each collection skill lives under `plugins/<collection>/skills/<name>/`, with an inbound symlink at `skills/<name>`:
 
 ```
-skills/
+plugins/<collection>/skills/
   my-skill/
     SKILL.md        # Required — skill definition
     rules/          # Optional — modular rule files
       some-rule.md
     references/     # Optional — per-language guides, loaded on demand
       python.md
+skills/my-skill -> ../plugins/<collection>/skills/my-skill
 ```
 
-See `AGENTS.md` for the frontmatter fields and what each one does; the quickest start is to copy the shape from an existing `skills/*/SKILL.md`. The validator enforces the required fields, so a missing one fails fast with a message naming it.
+See `AGENTS.md` for the frontmatter fields and what each one does; the quickest start is to copy the shape from an existing `plugins/*/skills/*/SKILL.md` (or the inbound `skills/*/SKILL.md`). The validator enforces the required fields, so a missing one fails fast with a message naming it.
 
 ## Writing a New Skill
 
-1. Create a directory: `skills/<skill-name>/` — the directory name must match the `name` field
+1. Create a directory: `plugins/<collection>/skills/<skill-name>/` — the directory name must match the `name` field
 2. Add `SKILL.md` with the required frontmatter
 3. Write the body as a lightweight guide rather than a rigid procedure. State a preference and its reason, then license the exception; `skills/setup/` is the reference for this style
 4. If the skill has multiple checks, add a `rules/` subdirectory with individual rule files and reference each from a table in `SKILL.md`. Every rule file must be referenced — unreferenced files fail validation as orphans
-5. Assign the skill to exactly one collection in the `collections` table in `scripts/validate-skills/main.go`, and add the matching symlink under `plugins/<collection>/skills/`
+5. Assign the skill to exactly one collection in the `collections` table in `scripts/validate-skills/main.go`, and add the inbound symlink `skills/<skill-name>` → `../plugins/<collection>/skills/<skill-name>`
 6. Open a pull request
 
 ## Plugin Metadata
 
-Plugin manifests are hand-maintained under `plugins/<name>/` — one per channel, described in `AGENTS.md`. There is no generator.
+Plugin manifests are hand-maintained under `plugins/<name>/` — root Agent Plugins `plugin.json` plus Claude Code, Cursor, and Antigravity overlays, described in `AGENTS.md`. There is no generator.
 
 Releases are cut by merging the release-please PR — **never bump versions by hand**. release-please syncs the plugin manifest versions from `.release-please-manifest.json` automatically.
 
@@ -71,7 +72,7 @@ This repository uses [conventional commits](https://www.conventionalcommits.org/
 
 - **Max 50 characters** for the subject line
 - Format: `type: description` — no scope (e.g. `feat: add deploy skill`, `fix: correct frontmatter field`)
-- **Skill markdown is the product, not docs.** Changes under `skills/**/*.md` use `feat`/`fix`/`refactor`; reserve `docs:` for `README.md`, `AGENTS.md`, `CLAUDE.md`, and similar meta-documentation
+- **Skill markdown is the product, not docs.** Changes under `plugins/*/skills/**/*.md` (and the inbound `skills/**/*.md` aliases) use `feat`/`fix`/`refactor`; reserve `docs:` for `README.md`, `AGENTS.md`, `CLAUDE.md`, and similar meta-documentation
 - A GitLeaks pre-commit hook runs on every commit to detect secrets — do not bypass it
 
 ## Pull Requests

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The deprecated all-in-one plugin remains installable as `tartinerlabs@tartinerla
 
 ### Codex Plugin
 
-This repository includes repo-scoped Codex plugin metadata in `plugins/<collection>/.codex-plugin/plugin.json` and `.agents/plugins/marketplace.json`.
+This repository includes Agent Plugins 1.0.0 manifests at `plugins/<collection>/plugin.json` (`extensions.com.openai` for Codex UI) and a repo-scoped marketplace at `.agents/plugins/marketplace.json`.
 
 To use it in Codex:
 
@@ -130,7 +130,7 @@ To use it in Codex:
 
 ### Cursor Plugin
 
-This repository includes Cursor plugin metadata in `plugins/<collection>/.cursor-plugin/plugin.json` and a repo-scoped marketplace at `.cursor-plugin/marketplace.json`.
+This repository includes Agent Plugins 1.0.0 manifests at `plugins/<collection>/plugin.json`, Cursor marketplace metadata in `plugins/<collection>/.cursor-plugin/plugin.json`, and a repo-scoped marketplace at `.cursor-plugin/marketplace.json`.
 
 To use it in Cursor:
 
@@ -188,7 +188,7 @@ pnpm dlx skills add tartinerlabs/skills/setup
 
 ## Plugin Metadata
 
-Plugin manifests are hand-maintained under `plugins/<name>/`, one per channel, with `.release-please-manifest.json` as the shared version source. See [AGENTS.md](AGENTS.md) for the layout and [CONTRIBUTING.md](CONTRIBUTING.md) to contribute.
+Plugin manifests are hand-maintained under `plugins/<name>/` — root Agent Plugins `plugin.json` for Cursor and Codex, plus Claude Code, Cursor, and Antigravity channel overlays — with `.release-please-manifest.json` as the shared version source. See [AGENTS.md](AGENTS.md) for the layout and [CONTRIBUTING.md](CONTRIBUTING.md) to contribute.
 
 ## Architecture
 


### PR DESCRIPTION
- Document Agent Plugins as the Cursor/Codex portable floor, with Claude and Antigravity still on channel overlays
- Describe inverted collection packaging and that tartinerlabs/xcode-skills wrappers remain non-conformant
- Direct new skills to `plugins/<collection>/skills/<name>/` plus an inbound `skills/<name>` symlink

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to packaging layout and contributor instructions; no runtime or validator changes.
> 
> **Overview**
> Updates contributor and agent docs to match inverted collection packaging and the Agent Plugins 1.0.0 floor.
> 
> Canonical skill trees now live at `plugins/<collection>/skills/<name>/`, with inbound `skills/<name>` symlinks for skills.sh and whole-directory wrappers. Cursor and Codex load root `plugin.json`; Claude Code and Antigravity keep channel overlays; Cursor marketplace still uses `.cursor-plugin/`. Notes that `tartinerlabs` and `xcode-skills` wrappers remain non-conformant because their `skills` links escape the plugin root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79d5569d13a776b4dad781cb0672a59c038ef018. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->