### PR TITLE
Validate inbound skill symlinks

### DIFF
--- a/.github/workflows/skills.yml
+++ b/.github/workflows/skills.yml
@@ -11,6 +11,7 @@ on:
       - main
     paths:
       - skills/**
+      - plugins/*/skills/**
       - xcode-skills/**
 
 jobs:

--- a/scripts/validate-skills/main.go
+++ b/scripts/validate-skills/main.go
@@ -15,10 +15,11 @@ import (
 	"strings"
 )
 
-// Skill collections: each entry is a `plugins/<name>/` wrapper exposing the
-// listed skills through per-skill symlinks (`skills/<skill>` →
-// `../../../skills/<skill>`). Every directory under `skills/` must belong to
-// exactly one collection — validated in validateCollections.
+// Skill collections: each entry is a `plugins/<name>/` wrapper that owns the
+// listed skill trees as real directories. The flat `skills/<skill>` path is
+// an inbound symlink to `../plugins/<collection>/skills/<skill>`. Every
+// skill under `skills/` must belong to exactly one collection — validated
+// in validateCollections.
 type collection struct {
 	name   string
 	skills []string
@@ -61,8 +62,9 @@ var marketplaces = []string{
 // Whole-directory wrappers expose their skill source through a `skills`
 // symlink that must point at a specific source — swapping the targets would
 // publish the wrong skills through that wrapper, so the exact destination is
-// checked. Collection wrappers instead use per-skill symlinks derived from
-// the collections table (validated in validateCollections).
+// checked. Collection wrappers own the real skill trees; inbound
+// `skills/<skill>` links are derived from the collections table (validated
+// in validateCollections).
 var wrapperSymlinks = []struct {
 	path   string
 	target string
@@ -150,23 +152,60 @@ func readJSON(root, relPath string, errors *[]string) map[string]interface{} {
 }
 
 func collectFiles(dir string, extensions []string) []string {
-	if !pathExists(dir) {
-		return nil
-	}
 	var files []string
-	filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
-		if err != nil || entry.IsDir() {
+	collectFilesInto(dir, extensions, map[string]bool{}, &files)
+	return files
+}
+
+// collectFilesInto walks dir, following directory symlinks (so inbound
+// `skills/<skill>` links are scanned) while reporting paths under the
+// original dir so callers still see `skills/<skill>/…`.
+func collectFilesInto(dir string, extensions []string, seen map[string]bool, files *[]string) {
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return
+	}
+	if seen[resolved] {
+		return
+	}
+	seen[resolved] = true
+
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return
+	}
+
+	filepath.WalkDir(resolved, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		rel, err := filepath.Rel(resolved, path)
+		if err != nil {
+			return nil
+		}
+		logical := dir
+		if rel != "." {
+			logical = filepath.Join(dir, rel)
+		}
+
+		if entry.Type()&os.ModeSymlink != 0 {
+			targetInfo, err := os.Stat(path)
+			if err == nil && targetInfo.IsDir() {
+				collectFilesInto(logical, extensions, seen, files)
+			}
+			return nil
+		}
+		if entry.IsDir() {
 			return nil
 		}
 		for _, extension := range extensions {
 			if strings.HasSuffix(entry.Name(), extension) {
-				files = append(files, path)
+				*files = append(*files, logical)
 				break
 			}
 		}
 		return nil
 	})
-	return files
 }
 
 func checkActionUses(root, file, source string, errors *[]string) {
@@ -452,6 +491,22 @@ func validatePlugins(root string, errors *[]string) {
 	}
 }
 
+func checkRealDir(root, dirPath string, errors *[]string) {
+	fullPath := filepath.Join(root, dirPath)
+	info, err := os.Lstat(fullPath)
+	if err != nil {
+		*errors = append(*errors, fmt.Sprintf("%s: directory not found", dirPath))
+		return
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		*errors = append(*errors, fmt.Sprintf("%s: expected a directory, not a symlink", dirPath))
+		return
+	}
+	if !info.IsDir() {
+		*errors = append(*errors, fmt.Sprintf("%s: expected a directory", dirPath))
+	}
+}
+
 func checkSymlink(root, linkPath, expectedTarget string, errors *[]string) {
 	fullPath := filepath.Join(root, linkPath)
 
@@ -490,10 +545,11 @@ func validateSymlinks(root string, errors *[]string) {
 	}
 }
 
-// Collection wrappers must expose exactly their assigned skills, each through
-// a per-skill symlink into the flat `skills/` source. Every skill in the
-// source must belong to exactly one collection so a newly added skill cannot
-// silently ship in none (or two) of the collection plugins.
+// Collection wrappers must own exactly their assigned skills as real
+// directories. The flat `skills/<skill>` path must be an inbound symlink
+// into that tree. Every skill in `skills/` must belong to exactly one
+// collection so a newly added skill cannot silently ship in none (or two)
+// of the collection plugins.
 func validateCollections(root string, skillNames []string, colls []collection, errors *[]string) {
 	assigned := map[string]string{}
 	for _, coll := range colls {
@@ -544,7 +600,8 @@ func validateCollections(root string, skillNames []string, colls []collection, e
 			}
 		}
 		for _, skill := range coll.skills {
-			checkSymlink(root, wrapperDir+"/"+skill, "../../../skills/"+skill, errors)
+			checkRealDir(root, wrapperDir+"/"+skill, errors)
+			checkSymlink(root, skillsDir+"/"+skill, "../"+wrapperDir+"/"+skill, errors)
 		}
 	}
 }
@@ -668,9 +725,11 @@ func validate(root string, colls []collection) []string {
 			errors = append(errors, fmt.Sprintf("%s/: %s", skillsDir, err))
 		}
 		for _, entry := range entries {
-			if entry.IsDir() {
-				skillNames = append(skillNames, entry.Name())
+			info, err := os.Stat(filepath.Join(skillsRoot, entry.Name()))
+			if err != nil || !info.IsDir() {
+				continue
 			}
+			skillNames = append(skillNames, entry.Name())
 		}
 		sort.Strings(skillNames)
 		for _, skillName := range skillNames {

--- a/scripts/validate-skills/main_test.go
+++ b/scripts/validate-skills/main_test.go
@@ -84,9 +84,9 @@ func buildFixture(t *testing.T) string {
 
 	writeJSONFile(t, filepath.Join(root, ".release-please-manifest.json"), map[string]string{".": version})
 
-	writeTextFile(t, filepath.Join(root, "skills/demo/SKILL.md"), validSkill)
-	writeTextFile(t, filepath.Join(root, "skills/demo/rules/foo.md"), "# Foo\n")
-
+	if err := os.MkdirAll(filepath.Join(root, "skills"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.MkdirAll(filepath.Join(root, "xcode-skills/sample"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -106,12 +106,10 @@ func buildFixture(t *testing.T) string {
 	mustSymlink(t, "../../xcode-skills", filepath.Join(root, "plugins/xcode-skills/skills"))
 
 	for _, coll := range fixtureCollections {
-		wrapperDir := filepath.Join(root, "plugins", coll.name, "skills")
-		if err := os.MkdirAll(wrapperDir, 0o755); err != nil {
-			t.Fatal(err)
-		}
 		for _, skill := range coll.skills {
-			mustSymlink(t, "../../../skills/"+skill, filepath.Join(wrapperDir, skill))
+			writeTextFile(t, filepath.Join(root, "plugins", coll.name, "skills", skill, "SKILL.md"), validSkill)
+			writeTextFile(t, filepath.Join(root, "plugins", coll.name, "skills", skill, "rules/foo.md"), "# Foo\n")
+			mustSymlink(t, "../plugins/"+coll.name+"/skills/"+skill, filepath.Join(root, "skills", skill))
 		}
 	}
 
@@ -300,19 +298,29 @@ func TestFlagsWrapperSymlinkPointingAtWrongCollection(t *testing.T) {
 	assertSomeError(t, validateFixture(root), "plugins/tartinerlabs/skills", "expected `../../skills`")
 }
 
-func TestFlagsMissingPerSkillCollectionSymlink(t *testing.T) {
+func TestFlagsMissingInboundSkillSymlink(t *testing.T) {
 	root := buildFixture(t)
-	mustRemove(t, filepath.Join(root, "plugins/workflow/skills/demo"))
-	assertSomeError(t, validateFixture(root), "plugins/workflow/skills/demo: broken or missing symlink")
+	mustRemove(t, filepath.Join(root, "skills/demo"))
+	assertSomeError(t, validateFixture(root), "skills/demo: broken or missing symlink")
 }
 
-func TestFlagsPerSkillCollectionSymlinkWithWrongTarget(t *testing.T) {
+func TestFlagsInboundSkillSymlinkWithWrongTarget(t *testing.T) {
 	root := buildFixture(t)
 	// Point at a valid, existing directory so only the target comparison can
 	// catch the swap.
-	mustRemove(t, filepath.Join(root, "plugins/workflow/skills/demo"))
-	mustSymlink(t, "../../../skills", filepath.Join(root, "plugins/workflow/skills/demo"))
-	assertSomeError(t, validateFixture(root), "plugins/workflow/skills/demo", "expected `../../../skills/demo`")
+	mustRemove(t, filepath.Join(root, "skills/demo"))
+	mustSymlink(t, "../plugins/workflow/skills", filepath.Join(root, "skills/demo"))
+	assertSomeError(t, validateFixture(root), "skills/demo", "expected `../plugins/workflow/skills/demo`")
+}
+
+func TestFlagsPluginSkillDirThatIsASymlink(t *testing.T) {
+	root := buildFixture(t)
+	pluginSkill := filepath.Join(root, "plugins/workflow/skills/demo")
+	if err := os.RemoveAll(pluginSkill); err != nil {
+		t.Fatal(err)
+	}
+	mustSymlink(t, "../../../skills/demo", pluginSkill)
+	assertSomeError(t, validateFixture(root), "plugins/workflow/skills/demo", "expected a directory, not a symlink")
 }
 
 func TestFlagsEntryACollectionWrapperShouldNotExpose(t *testing.T) {
@@ -388,8 +396,8 @@ func TestAllowsMutableRefsOnlyInActionPinningIncorrectSection(t *testing.T) {
 	root := buildFixture(t)
 	githubActionsSkill := strings.ReplaceAll(validSkill, "demo", "github-actions")
 	githubActionsSkill = strings.ReplaceAll(githubActionsSkill, "rules/foo.md", "rules/action-pinning.md")
-	writeTextFile(t, filepath.Join(root, "skills/github-actions/SKILL.md"), githubActionsSkill)
-	writeTextFile(t, filepath.Join(root, "skills/github-actions/rules/action-pinning.md"), strings.Join([]string{
+	writeTextFile(t, filepath.Join(root, "plugins/workflow/skills/github-actions/SKILL.md"), githubActionsSkill)
+	writeTextFile(t, filepath.Join(root, "plugins/workflow/skills/github-actions/rules/action-pinning.md"), strings.Join([]string{
 		"# Action Pinning",
 		"",
 		"### Incorrect",
@@ -401,8 +409,8 @@ func TestAllowsMutableRefsOnlyInActionPinningIncorrectSection(t *testing.T) {
 		"- uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0",
 		"",
 	}, "\n"))
-	mustSymlink(t, "../../../skills/github-actions",
-		filepath.Join(root, "plugins/workflow/skills/github-actions"))
+	mustSymlink(t, "../plugins/workflow/skills/github-actions",
+		filepath.Join(root, "skills/github-actions"))
 	errors := validate(root, []collection{
 		{name: "workflow", skills: []string{"demo", "github-actions"}},
 	})
@@ -441,12 +449,13 @@ func secondSkill(name, body string) string {
 	}, "\n")
 }
 
-// addSecondSkill writes a second skill and wires up its collection symlink.
+// addSecondSkill writes a second skill into the collection tree and an
+// inbound `skills/<name>` symlink.
 func addSecondSkill(t *testing.T, root, name, body string) {
 	t.Helper()
-	writeTextFile(t, filepath.Join(root, "skills", name, "SKILL.md"), secondSkill(name, body))
-	writeTextFile(t, filepath.Join(root, "skills", name, "rules/bar.md"), "# Bar\n")
-	mustSymlink(t, "../../../skills/"+name, filepath.Join(root, "plugins/workflow/skills/"+name))
+	writeTextFile(t, filepath.Join(root, "plugins/workflow/skills", name, "SKILL.md"), secondSkill(name, body))
+	writeTextFile(t, filepath.Join(root, "plugins/workflow/skills", name, "rules/bar.md"), "# Bar\n")
+	mustSymlink(t, "../plugins/workflow/skills/"+name, filepath.Join(root, "skills", name))
 }
 
 func twoSkillCollections(name string) []collection {


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tartinerlabs/codesmith/skills/pr/83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790015879&installation_model_id=427837&pr_number=83&repository=tartinerlabs%2Fskills&return_to=https%3A%2F%2Fgithub.com%2Ftartinerlabs%2Fskills%2Fpull%2F83&signature=103e9eef594e0a2c895b3ea917b91ba23e8f6c5da613cfd5f669287ea0e1ddbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the skill-layout contract and CI path filters. A validator bug could miss a broken layout or fail valid trees, but this is repo structure validation, not runtime auth or data handling.
> 
> **Overview**
> Reverses the collection layout the validator enforces: **plugin wrappers now own real skill directories**, and `skills/<skill>` must be an inbound symlink into that tree (not the other way around).
> 
> `validateCollections` checks each assigned skill is a real directory under `plugins/<collection>/skills/` and that the matching `skills/<skill>` link points at it. File collection follows those inbound directory links so content checks still report paths under `skills/`. The skills workflow also runs when `plugins/*/skills/**` changes.
> 
> Tests rebuild fixtures in the new layout and cover missing/wrong inbound links plus a plugin skill path that is still a symlink.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b806b2ee560061342fa7c8382c18458ae14541f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->